### PR TITLE
Code cleanup and move getCoins definition outside useEffect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ function App() {
 	return (
 		<div className="App">
 			<header className="App-header">
-				<h1>🖕Coin Tracker🖕</h1>
+				<h1>Coin Tracker</h1>
 			</header>
 			<section>
 				<TopTen />

--- a/src/components/TopTen.jsx
+++ b/src/components/TopTen.jsx
@@ -5,24 +5,24 @@ import Crypto from './Crypto';
 const clientAPI = new CoinpaprikaAPI();
 
 const TopTen = () => {
-  const updateInterval = 10000;
+  const updateInterval = 3000;
   const numOfCoins = 10;
   const [currCoins, setCurrCoins] = useState([]);
 
+	const getCoins = () => {
+		clientAPI
+			.getAllTickers()
+			.then((data) => {
+				data = data.filter((value, index) => index < numOfCoins);
+				data = data.map((element, index) => <Crypto key={index} currCoin={element} />);
+				setCurrCoins(data);
+			})
+			.catch(console.error);
+	};
+	
   useEffect(() => {
-    const getCoins = () => {
-      clientAPI
-        .getAllTickers()
-        .then((data) => {
-          data = data.filter((value, index) => index < numOfCoins);
-          data = data.map((element, index) => <Crypto key={index} currCoin={element} />);
-          setCurrCoins(data);
-        })
-        .catch(console.error);
-    };
-    getCoins();
+		getCoins();
     const interval = setInterval(getCoins, updateInterval);
-
     return () => clearInterval(interval);
   }, []);
 

--- a/src/components/TopTen.jsx
+++ b/src/components/TopTen.jsx
@@ -1,10 +1,10 @@
 // React function component
 import CoinpaprikaAPI from '@coinpaprika/api-nodejs-client';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import Crypto from './Crypto';
 const clientAPI = new CoinpaprikaAPI();
 
-const TopTen = (props) => {
+const TopTen = () => {
   const updateInterval = 10000;
   const numOfCoins = 10;
   const [currCoins, setCurrCoins] = useState([]);


### PR DESCRIPTION
Just moved getCoins out of useEffect because it was painful to look at and get the impression that you need to define the function in useEffect which you don't. So now only lines that do something are in useEffect which makes its purpose more clear.(to me at least) 